### PR TITLE
Implemented profanity censoring, checking, and replacing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod v1 {
     pub mod routes;
 }
 
-use v1::routes::censor_text;
+use v1::routes;
 
 #[get("/")]
 async fn index() -> impl Responder {
@@ -12,8 +12,12 @@ async fn index() -> impl Responder {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    HttpServer::new(|| App::new().service(censor_text).service(index))
-        .bind(("127.0.0.1", 8080))?
-        .run()
-        .await
+    HttpServer::new(|| {
+        App::new()
+            .service(routes::censor_text)
+            .service(routes::check_text)
+    })
+    .bind(("127.0.0.1", 8080))?
+    .run()
+    .await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,37 +1,18 @@
-use actix_web::{get, post, web, App, HttpResponse, HttpServer, Responder};
-use censor::*;
-use serde::Deserialize;
-
-#[derive(Deserialize)]
-struct IncomingReqBody {
-    content: Option<String>,
+use actix_web::{get, App, HttpResponse, HttpServer, Responder};
+mod v1 {
+    pub mod routes;
 }
+
+use v1::routes::censor_text;
 
 #[get("/")]
 async fn index() -> impl Responder {
     HttpResponse::Ok().body("Hello world!")
 }
 
-#[post("/check")]
-async fn check(req_body: web::Json<IncomingReqBody>) -> impl Responder {
-    let content = req_body
-        .content
-        .clone()
-        .unwrap_or_else(|| "No content".to_string());
-
-    let censor = Censor::Standard;
-
-    if censor.check(&content) {
-        let censored_content = censor.censor(&content);
-        return HttpResponse::Ok().body(censored_content);
-    }
-
-    HttpResponse::Ok().body(content)
-}
-
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    HttpServer::new(|| App::new().service(check).service(index))
+    HttpServer::new(|| App::new().service(censor_text).service(index))
         .bind(("127.0.0.1", 8080))?
         .run()
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ async fn main() -> std::io::Result<()> {
         App::new()
             .service(routes::censor_text)
             .service(routes::check_text)
+            .service(routes::replace_text)
     })
     .bind(("127.0.0.1", 8080))?
     .run()

--- a/src/v1/routes.rs
+++ b/src/v1/routes.rs
@@ -15,6 +15,11 @@ struct IncomingReqBody {
     content: Option<String>,
 }
 
+/// Represents the incoming request query param containing the gawlix for replacing text.
+///
+/// # Fields
+///
+/// * `grawlix` - A query param `String` that holds the grawlix content.
 #[derive(Deserialize)]
 struct GrawlixQueryParams {
     grawlix: String,

--- a/src/v1/routes.rs
+++ b/src/v1/routes.rs
@@ -3,18 +3,34 @@ use actix_web::{post, web, HttpResponse, Responder};
 use censor::*;
 use serde::Deserialize;
 
+const NO_CONTENT_STRING: &str = "No content sent to API.";
+
+/// Represents the incoming request body containing optional text content.
+///
+/// # Fields
+///
+/// * `content` - An optional `String` that holds the text content to be processed.
 #[derive(Deserialize)]
-pub struct IncomingReqBody {
-    pub content: Option<String>,
+struct IncomingReqBody {
+    content: Option<String>,
 }
 
+/// Asynchronously checks if the provided text contains profanity.
+///
+/// # Arguments
+///
+/// * `req_body` - A JSON object containing the text to be checked.
+///
+/// # Returns
+///
+/// * `HttpResponse` - Returns `true` if the text contains profanity, otherwise `false`.
 #[post("/api/v1/check-text")]
 pub async fn check_text(req_body: web::Json<IncomingReqBody>) -> impl Responder {
     // Returns Bool
     let content = req_body
         .content
         .clone()
-        .unwrap_or_else(|| "No content".to_string());
+        .unwrap_or_else(|| NO_CONTENT_STRING.to_string());
 
     let censor = Censor::Standard;
 
@@ -25,13 +41,22 @@ pub async fn check_text(req_body: web::Json<IncomingReqBody>) -> impl Responder 
     HttpResponse::Ok().json(false) // content does not have profanity, return false
 }
 
+/// Asynchronously censors any profanity in the provided text.
+///
+/// # Arguments
+///
+/// * `req_body` - A JSON object containing the text to be censored.
+///
+/// # Returns
+///
+/// * `HttpResponse` - Returns the censored text if profanity is found, otherwise returns the original text.
 #[post("/api/v1/censor-text")]
 pub async fn censor_text(req_body: web::Json<IncomingReqBody>) -> impl Responder {
     // Returns String
     let content = req_body
         .content
         .clone()
-        .unwrap_or_else(|| "No content".to_string());
+        .unwrap_or_else(|| NO_CONTENT_STRING.to_string());
 
     let censor = Censor::Standard;
 
@@ -42,3 +67,6 @@ pub async fn censor_text(req_body: web::Json<IncomingReqBody>) -> impl Responder
 
     HttpResponse::Ok().body(content) // content does not have profanity, return original
 }
+
+// Implement censor_replace
+// https://docs.rs/censor/latest/censor/

--- a/src/v1/routes.rs
+++ b/src/v1/routes.rs
@@ -15,6 +15,11 @@ struct IncomingReqBody {
     content: Option<String>,
 }
 
+#[derive(Deserialize)]
+struct GrawlixQueryParams {
+    grawlix: String,
+}
+
 /// Asynchronously checks if the provided text contains profanity.
 ///
 /// # Arguments
@@ -68,5 +73,37 @@ pub async fn censor_text(req_body: web::Json<IncomingReqBody>) -> impl Responder
     HttpResponse::Ok().body(content) // content does not have profanity, return original
 }
 
-// Implement censor_replace
-// https://docs.rs/censor/latest/censor/
+/// This function handles POST requests to the `/api/v1/replace-text` endpoint.
+/// It takes a JSON body and query parameters, processes the content, and returns
+/// a censored version of the text if any inappropriate content is found.
+///
+/// # Arguments
+///
+/// * `req_body` - A JSON body containing the content to be processed.
+/// * `grawlix_input` - Query parameters containing the grawlix string to replace inappropriate content.
+///
+/// # Returns
+///
+/// * `HttpResponse` - Returns an HTTP response with the processed content. If inappropriate content is found,
+/// it is replaced with the grawlix string. Otherwise, the original content is returned.
+#[post("/api/v1/replace-text")]
+pub async fn replace_text(
+    req_body: web::Json<IncomingReqBody>,
+    grawlix_input: web::Query<GrawlixQueryParams>,
+) -> impl Responder {
+    //
+    let content = req_body
+        .content
+        .clone()
+        .unwrap_or_else(|| NO_CONTENT_STRING.to_string());
+
+    let grawlix_clone = grawlix_input.grawlix.clone();
+    let censor = Censor::Standard;
+
+    if censor.check(&content) {
+        let replaced_content = censor.replace(&content, &grawlix_clone);
+        return HttpResponse::Ok().body(replaced_content);
+    }
+
+    HttpResponse::Ok().body(content)
+}

--- a/src/v1/routes.rs
+++ b/src/v1/routes.rs
@@ -1,0 +1,44 @@
+use actix_web::{post, web, HttpResponse, Responder};
+
+use censor::*;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct IncomingReqBody {
+    pub content: Option<String>,
+}
+
+#[post("/api/v1/check-text")]
+pub async fn check_text(req_body: web::Json<IncomingReqBody>) -> impl Responder {
+    // Returns Bool
+    let content = req_body
+        .content
+        .clone()
+        .unwrap_or_else(|| "No content".to_string());
+
+    let censor = Censor::Standard;
+
+    if censor.check(&content) {
+        return HttpResponse::Ok().json(true); // content has profanity, return true
+    }
+
+    HttpResponse::Ok().json(false) // content does not have profanity, return false
+}
+
+#[post("/api/v1/censor-text")]
+pub async fn censor_text(req_body: web::Json<IncomingReqBody>) -> impl Responder {
+    // Returns String
+    let content = req_body
+        .content
+        .clone()
+        .unwrap_or_else(|| "No content".to_string());
+
+    let censor = Censor::Standard;
+
+    if censor.check(&content) {
+        let censored_content = censor.censor(&content);
+        return HttpResponse::Ok().body(censored_content); // content has profanity, return censored
+    }
+
+    HttpResponse::Ok().body(content) // content does not have profanity, return original
+}


### PR DESCRIPTION
# CONST's TO BE IMPLEMENTED:

```rust
const NO_CONTENT_STRING: &str = "No content sent to API.";
```

# STRUCTS TO BE IMPLEMENTED:

```rust
/// Represents the incoming request body containing optional text content.
///
/// # Fields
///
/// * `content` - An optional `String` that holds the text content to be processed.
#[derive(Deserialize)]
struct IncomingReqBody {
    content: Option<String>,
}

/// Represents the incoming request query param containing the gawlix for replacing text.
///
/// # Fields
///
/// * `grawlix` - A query param `String` that holds the grawlix content.
#[derive(Deserialize)]
struct GrawlixQueryParams {
    grawlix: String,
}
```

# FUNCTIONS TO BE IMPLEMENTED:

```rust 
/// Asynchronously checks if the provided text contains profanity.
///
/// # Arguments
///
/// * `req_body` - A JSON object containing the text to be checked.
///
/// # Returns
///
/// * `HttpResponse` - Returns `true` if the text contains profanity, otherwise `false`.
#[post("/api/v1/check-text")]
pub async fn check_text(req_body: web::Json<IncomingReqBody>) -> impl Responder {
    // Returns Bool
    let content = req_body
        .content
        .clone()
        .unwrap_or_else(|| NO_CONTENT_STRING.to_string());

    let censor = Censor::Standard;

    if censor.check(&content) {
        return HttpResponse::Ok().json(true); // content has profanity, return true
    }

    HttpResponse::Ok().json(false) // content does not have profanity, return false
}

/// Asynchronously censors any profanity in the provided text.
///
/// # Arguments
///
/// * `req_body` - A JSON object containing the text to be censored.
///
/// # Returns
///
/// * `HttpResponse` - Returns the censored text if profanity is found, otherwise returns the original text.
#[post("/api/v1/censor-text")]
pub async fn censor_text(req_body: web::Json<IncomingReqBody>) -> impl Responder {
    // Returns String
    let content = req_body
        .content
        .clone()
        .unwrap_or_else(|| NO_CONTENT_STRING.to_string());

    let censor = Censor::Standard;

    if censor.check(&content) {
        let censored_content = censor.censor(&content);
        return HttpResponse::Ok().body(censored_content); // content has profanity, return censored
    }

    HttpResponse::Ok().body(content) // content does not have profanity, return original
}

/// This function handles POST requests to the `/api/v1/replace-text` endpoint.
/// It takes a JSON body and query parameters, processes the content, and returns
/// a censored version of the text if any inappropriate content is found.
///
/// # Arguments
///
/// * `req_body` - A JSON body containing the content to be processed.
/// * `grawlix_input` - Query parameters containing the grawlix string to replace inappropriate content.
///
/// # Returns
///
/// * `HttpResponse` - Returns an HTTP response with the processed content. If inappropriate content is found,
/// it is replaced with the grawlix string. Otherwise, the original content is returned.
#[post("/api/v1/replace-text")]
pub async fn replace_text(
    req_body: web::Json<IncomingReqBody>,
    grawlix_input: web::Query<GrawlixQueryParams>,
) -> impl Responder {
    //
    let content = req_body
        .content
        .clone()
        .unwrap_or_else(|| NO_CONTENT_STRING.to_string());

    let grawlix_clone = grawlix_input.grawlix.clone();
    let censor = Censor::Standard;

    if censor.check(&content) {
        let replaced_content = censor.replace(&content, &grawlix_clone);
        return HttpResponse::Ok().body(replaced_content);
    }

    HttpResponse::Ok().body(content)
}
```